### PR TITLE
chore: Update package manager

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -18,6 +18,7 @@ sudo apt-get clean
 sudo rm -rf /var/lib/apt/lists/*
 
 sudo chown node:node /workspaces
+sudo chown -R node:node /workspaces/majiang-log/node_modules
 
 sudo corepack enable npm
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -12,12 +12,12 @@ if [[ -t 1 ]] && type -t tput >/dev/null; then
   fi
 fi
 
-sudo chown -R node .
-
 sudo apt-get update
 sudo apt-get upgrade -y
 sudo apt-get clean
 sudo rm -rf /var/lib/apt/lists/*
+
+sudo chown node:node /workspaces
 
 sudo corepack enable npm
 export COREPACK_ENABLE_DOWNLOAD_PROMPT=0

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -2,7 +2,7 @@
 
 set -euxo pipefail
 
-# Set up colorful debug output for the script
+# Set up colorful debug output
 PS4='+${BASH_SOURCE[0]}:$LINENO: '
 if [[ -t 1 ]] && type -t tput >/dev/null; then
   if (( "$(tput colors)" == 256 )); then

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -2,6 +2,16 @@
 
 set -euxo pipefail
 
+# Set up colorful debug output for the script
+PS4='+${BASH_SOURCE[0]}:$LINENO: '
+if [[ -t 1 ]] && type -t tput >/dev/null; then
+  if (( "$(tput colors)" == 256 )); then
+    PS4='$(tput setaf 10)'$PS4'$(tput sgr0)'
+  else
+    PS4='$(tput setaf 2)'$PS4'$(tput sgr0)'
+  fi
+fi
+
 sudo chown -R node .
 
 sudo apt-get update

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "url": "https://github.com/Apricot-S/majiang-log/issues"
   },
   "type": "module",
-  "packageManager": "npm@10.8.2+sha512.c7f0088c520a46596b85c6f8f1da943400199748a0f7ea8cb8df75469668dc26f6fb3ba26df87e2884a5ebe91557292d0f3db7d0929cdb4f14910c3032ac81fb",
+  "packageManager": "npm@10.8.3+sha512.d08425c8062f56d43bb8e84315864218af2492eb769e1f1ca40740f44e85bd148969382d651660363942e5909cb7ffcbef7ca0ae963ddc2c57a51243b4da8f56",
   "files": [
     "dist"
   ],


### PR DESCRIPTION
`npm` を 10.8.3 にアップデートする。
2024/10/26 現在の最新バージョンは 10.9.0 だが、`npm install` や `npm update` が大幅に遅くなる問題が発生しているため、一つ手前のバージョンの 10.8.3 を指定する。