### PR TITLE
feat: Export types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,2 @@
-export { convertLog } from './lib/convertLog.js';
+export { Mode, MODE } from './lib/mode.js';
+export { convertLog, TenhouLog, TenhouViewerUrls } from './lib/convertLog.js';

--- a/src/lib/convertLog.ts
+++ b/src/lib/convertLog.ts
@@ -138,7 +138,7 @@ const logToUrls = (log: TenhouLog): TenhouViewerUrls => {
   });
 };
 
-export const convertLog = (
+const convertLog = (
   input: object,
   mode: string,
 ): TenhouLog | TenhouViewerUrls => {
@@ -169,3 +169,5 @@ export const convertLog = (
       return assertNever(mode);
   }
 };
+
+export { convertLog, TenhouLog, TenhouViewerUrls };


### PR DESCRIPTION
`convertLog` の戻り値の型を `export` する。
また、引数の `mode` に指定できる値の定数 `MODE` およびその型 `Mode` も `export` する。