### PR TITLE
chore: Update Node.js to v22

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "name": "majiang-log",
   "runArgs": ["--name=majiang-log-dev"],
   // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
-  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm",
 
   // Features to add to the dev container. More info: https://containers.dev/features.
   // "features": {},

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -20,6 +20,5 @@ sudo rm -rf /var/lib/apt/lists/*
 sudo chown node:node /workspaces
 sudo chown -R node:node /workspaces/majiang-log/node_modules
 
-sudo corepack enable npm
-export COREPACK_ENABLE_DOWNLOAD_PROMPT=0
+npm install -g npm
 npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG NODE_VERSION=20
+ARG NODE_VERSION=22
 ARG OS_VERSION=bookworm-slim
 
 FROM node:${NODE_VERSION}-${OS_VERSION} AS base

--- a/biome.json
+++ b/biome.json
@@ -11,7 +11,8 @@
       "**/dist/**/*",
       "**/examples/**/*",
       "**/node_modules/**/*",
-      "**/package-lock.json"
+      "**/package-lock.json",
+      "**/package.json"
     ]
   },
   "formatter": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "vitest": "^2.1.3"
       },
       "engines": {
-        "node": ">=20.14.0"
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@babel/runtime": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "url": "https://github.com/Apricot-S/majiang-log/issues"
   },
   "type": "module",
-  "packageManager": "npm@10.8.3+sha512.d08425c8062f56d43bb8e84315864218af2492eb769e1f1ca40740f44e85bd148969382d651660363942e5909cb7ffcbef7ca0ae963ddc2c57a51243b4da8f56",
   "files": [
     "dist"
   ],
@@ -57,6 +56,6 @@
     "vitest": "^2.1.3"
   },
   "engines": {
-    "node": ">=20.14.0"
+    "node": ">=22.12.0"
   }
 }


### PR DESCRIPTION
Node.js を v20 から v22 に変更する。
corepack が非推奨となったため、DevContainer の npm は単純に最新版をインストールするように変更する。

また、`package.json` が npm 以外で書き換わらないように `biome.json` の除外対象に追加する。