### PR TITLE
docs: Add usage as a library

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ majiang-log-server &
 curl -sS http://127.0.0.1:8001/majiang-log/log -H 'Content-Type: application/json' -d @PATH/TO/majiang-game-record.json -o PATH/TO/your-favorite-name.txt
 ```
 
+### ライブラリとして
+
+```ts
+import { convertLog, MODE } from '@apricot-s/majiang-log';
+
+// Game record (JSON in Majiang format)
+const paipu = {
+  /* Game record data */
+};
+
+const mode = MODE.Log; // or MODE.Viewer
+
+const result = convertLog(paipu, mode);
+```
+
 ## オプション / Option
 
 ### majiang-log [--mode *(log|viewer)*]


### PR DESCRIPTION
API として export はしていたが README に記載していなかった。
API 仕様の記述方法は JSDoc, TSDoc などの利用など検討中のため、今回は使用方法のみ追記する。